### PR TITLE
customisable comma and colon signs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Upgrade bash-completion scripts from https://github.com/mernen/completion-ruby
 - Add github action, shellcheck
+- Add `DFL_PROMPT_IPS_LIST_SEPERATOR` and `DFL_PROMPT_IPS_LIST_COLON` for `PROMPT_IPS_LIST`
+- Add `DFL_PROMPT_HORIZONTAL_LINE` for custom char option for `PROMPT_HORIZONTAL_LINE`
+- Add `DFL_PROMPT_GIT_AT_SIGN` for custom look and feel
 
 **April 29, 2021, Corona Days**
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ Try these commands:
 
 - Upgrade bash-completion scripts from https://github.com/mernen/completion-ruby
 - Add github action, shellcheck
+- Add `DFL_PROMPT_IPS_LIST_SEPERATOR` and `DFL_PROMPT_IPS_LIST_COLON` for `PROMPT_IPS_LIST`
+- Add `DFL_PROMPT_HORIZONTAL_LINE` for custom char option for `PROMPT_HORIZONTAL_LINE`
+- Add `DFL_PROMPT_GIT_AT_SIGN` for custom look and feel
 
 **April 29, 2021, Corona Days**
 
@@ -389,17 +392,19 @@ This works if you are under a **git repository**. Shows current status such
 as; added, modified, deleted, renamed, type changed files amount. Example:
 
     [master @ 297c543ceac8 □:1 ◆:1 ◌:1 | 3] (7 minutes ago) [v1.3.0]
-       |      |            |   |   |     |        |            |
-       |      |            |   |   |     |        |            +---> enabled via DFL_REVCONTROL_GIT_SHOW_LATEST_TAG
-       |      |            |   |   |     |        |
-       |      |            |   |   |     |        +---> enabled via DFL_REVCONTROL_GIT_SHOW_DIFF_SINCE_LAST_COMMIT
-       |      |            |   |   |     |
-       |      |            |   |   |     +-> 3 files will be affected   
-       |      |            |   |   +-------> 1 file is deleted
-       |      |            |   +-----------> 1 file is modified
-       |      |            +---------------> 1 file is untracked
-       |      +----------------------------> commit id
-       +-----------------------------------> current branch
+       |    | |            |   |   |     |        |            |
+       |    | |            |   |   |     |        |            +---> enabled via DFL_REVCONTROL_GIT_SHOW_LATEST_TAG
+       |    | |            |   |   |     |        |
+       |    | |            |   |   |     |        +---> enabled via DFL_REVCONTROL_GIT_SHOW_DIFF_SINCE_LAST_COMMIT
+       |    | |            |   |   |     |
+       |    | |            |   |   |     +-> 3 files will be affected   
+       |    | |            |   |   +-------> 1 file is deleted
+       |    | |            |   +-----------> 1 file is modified
+       |    | |            +---------------> 1 file is untracked
+       |    | +----------------------------> commit id
+       +----+------------------------------> current branch
+            |
+      DFL_PROMPT_GIT_AT_SIGN is set to " @ "
     
     [development @ b09ab92a87d5 □:1 | 1 →1] (7 minutes ago)
                                         |
@@ -506,7 +511,8 @@ macOS only, shows current `pgvm` active version. Color variable is `DFL_PGVM_PRO
 #### `${PROMPT_IPS_LIST}`
 
 Shows current available local ip list. Color variables are `DFL_IPLIST_PROMPT_IFACE_COLOR`
-and `DFL_IPLIST_PROMPT_IPADDR_COLOR`.
+and `DFL_IPLIST_PROMPT_IPADDR_COLOR`. You can customize `:` and `,` via 
+`DFL_PROMPT_IPS_LIST_SEPERATOR` and `DFL_PROMPT_IPS_LIST_COLON` variables
 
     [en0:192.168.2.205,vboxnet0:192.168.33.1]
     # name of interface: IP
@@ -538,7 +544,8 @@ shows an indicator if any of them is/are running. Color variables are:
 #### `${PROMPT_HORIZONTAL_LINE}`
 
 Draws dashed line along the terminal width. This separates commands. Color
-variable is `DFL_HORIZONTAL_LINE_PROMPT_COLOR`.
+variable is `DFL_HORIZONTAL_LINE_PROMPT_COLOR`. You can configure line char
+via `DFL_PROMPT_HORIZONTAL_LINE` variable. Default is set to `-`
 
 #### `${PROMPT_DOCKER_STATUS}`
 

--- a/ps1/git
+++ b/ps1/git
@@ -186,7 +186,7 @@ cwd_anything_changed() {
 if [[ $(command -v git) ]]; then
     if in_git_repo; then
         branch=$(git_parse_branch)
-        at_sign="@"
+        at_sign="${DFL_PROMPT_GIT_AT_SIGN}"
         commit_id=$(git rev-parse --short HEAD 2>/dev/null || echo 'no-commit-id')
         rebasing=$(any_rebasing)
         anything_changed=$(cwd_anything_changed)
@@ -210,7 +210,7 @@ if [[ $(command -v git) ]]; then
         if [[ $DFL_REVCONTROL_COMMIT_ID_COLOR ]]; then
             commit_id="${DFL_REVCONTROL_COMMIT_ID_COLOR}${commit_id}${COLOR_OFF}"
         fi
-        at_sign=" ${at_sign} "
+        at_sign="${at_sign}"
         
         latest_tag=""
         if [[ $DFL_REVCONTROL_GIT_SHOW_LATEST_TAG ]]; then

--- a/ps1/git
+++ b/ps1/git
@@ -186,7 +186,7 @@ cwd_anything_changed() {
 if [[ $(command -v git) ]]; then
     if in_git_repo; then
         branch=$(git_parse_branch)
-        at_sign="${DFL_PROMPT_GIT_AT_SIGN}"
+        at_sign="${DFL_PROMPT_GIT_AT_SIGN:- @ }"
         commit_id=$(git rev-parse --short HEAD 2>/dev/null || echo 'no-commit-id')
         rebasing=$(any_rebasing)
         anything_changed=$(cwd_anything_changed)
@@ -210,7 +210,6 @@ if [[ $(command -v git) ]]; then
         if [[ $DFL_REVCONTROL_COMMIT_ID_COLOR ]]; then
             commit_id="${DFL_REVCONTROL_COMMIT_ID_COLOR}${commit_id}${COLOR_OFF}"
         fi
-        at_sign="${at_sign}"
         
         latest_tag=""
         if [[ $DFL_REVCONTROL_GIT_SHOW_LATEST_TAG ]]; then

--- a/ps1/ip-list
+++ b/ps1/ip-list
@@ -34,7 +34,8 @@ if [[ $(command -v ifconfig) ]]; then
             if [[ $DFL_IPLIST_PROMPT_IPADDR_COLOR ]]; then
                 ip_address="${DFL_IPLIST_PROMPT_IPADDR_COLOR}${DFL_PROMPT_BRACKET_OPEN}${ip_address}${DFL_PROMPT_BRACKET_CLOSE}${COLOR_OFF}"
             fi
-            iface_and_ip=$(printf ",%s: %s" "${iface}" "${ip_address}")
+            # iface_and_ip=$(printf "${DFL_PROMPT_IPS_LIST_COMMA}%s${DFL_PROMPT_IPS_LIST_COLON} %s" "${iface}" "${ip_address}")
+            iface_and_ip=$(printf "${DFL_PROMPT_IPS_LIST_COMMA}%s${DFL_PROMPT_IPS_LIST_COLON}%s" "${iface}" "${ip_address}")
             output+=("${iface_and_ip}")
         fi
     done

--- a/ps1/ip-list
+++ b/ps1/ip-list
@@ -34,8 +34,7 @@ if [[ $(command -v ifconfig) ]]; then
             if [[ $DFL_IPLIST_PROMPT_IPADDR_COLOR ]]; then
                 ip_address="${DFL_IPLIST_PROMPT_IPADDR_COLOR}${DFL_PROMPT_BRACKET_OPEN}${ip_address}${DFL_PROMPT_BRACKET_CLOSE}${COLOR_OFF}"
             fi
-            # iface_and_ip=$(printf "${DFL_PROMPT_IPS_LIST_COMMA}%s${DFL_PROMPT_IPS_LIST_COLON} %s" "${iface}" "${ip_address}")
-            iface_and_ip=$(printf "${DFL_PROMPT_IPS_LIST_COMMA}%s${DFL_PROMPT_IPS_LIST_COLON}%s" "${iface}" "${ip_address}")
+            iface_and_ip=$(printf "%s%s%s %s" "${DFL_PROMPT_IPS_LIST_SEPERATOR:-,}" "${iface}" "${DFL_PROMPT_IPS_LIST_COLON:-:}" "${ip_address}")
             output+=("${iface_and_ip}")
         fi
     done

--- a/startup-sequence/ps1-setup
+++ b/startup-sequence/ps1-setup
@@ -1,19 +1,25 @@
 # shellcheck disable=SC2034
 export DFL_PROMPT_BRACKET_OPEN="${DFL_PROMPT_BRACKET_OPEN:-[}"
 export DFL_PROMPT_BRACKET_CLOSE="${DFL_PROMPT_BRACKET_CLOSE:-]}"
+export DFL_PROMPT_IPS_LIST_COMMA="${DFL_PROMPT_IPS_LIST_COMMA:-,}"
+export DFL_PROMPT_IPS_LIST_COLON="${DFL_PROMPT_IPS_LIST_COLON:-:}"
+export DFL_PROMPT_GIT_AT_SIGN="${DFL_PROMPT_IPS_LIST_SPACE:- @ }"
+export DFL_PROMPT_HORIZONTAL_LINE="${DFL_PROMPT_HORIZONTAL_LINE:-}"
+export DFL_PROMPT_TOP_LINE_FIRST_CHAR="${DFL_PROMPT_TOP_LINE_FIRST_CHAR: }"
+export DFL_PROMPT_MID_LINE_FIRST_CHAR="${DFL_PROMPT_MID_LINE_FIRST_CHAR: }"
+export DFL_PROMPT_GIT_LINE_FIRST_CHAR="${DFL_PROMPT_GIT_LINE_FIRST_CHAR: }"
+export DFL_PROMPT_END_LINE_FIRST_CHAR="${DFL_PROMPT_END_LINE_FIRST_CHAR: }"
 
 # shellcheck disable=SC2148
 # -----------------------------------------------------------------------------
 print_horizontal_line(){
     cols=${COLUMNS:-$(tty -s && tput cols)}
-    hline=$(printf "%*s\n" "${cols}" "" | tr " " -)
+    hline=$(printf "%*s\n" "${cols}" "" | tr " " ${DFL_PROMPT_HORIZONTAL_LINE})
     if [[ $DFL_HORIZONTAL_LINE_PROMPT_COLOR ]]; then
         hline="${DFL_HORIZONTAL_LINE_PROMPT_COLOR}${hline}${COLOR_OFF}"
     fi
     echo -e "${hline}"
 }
-# -----------------------------------------------------------------------------
-
 
 # -----------------------------------------------------------------------------
 # shellcheck disable=SC2034

--- a/startup-sequence/ps1-setup
+++ b/startup-sequence/ps1-setup
@@ -1,20 +1,12 @@
 # shellcheck disable=SC2034
 export DFL_PROMPT_BRACKET_OPEN="${DFL_PROMPT_BRACKET_OPEN:-[}"
 export DFL_PROMPT_BRACKET_CLOSE="${DFL_PROMPT_BRACKET_CLOSE:-]}"
-export DFL_PROMPT_IPS_LIST_COMMA="${DFL_PROMPT_IPS_LIST_COMMA:-,}"
-export DFL_PROMPT_IPS_LIST_COLON="${DFL_PROMPT_IPS_LIST_COLON:-:}"
-export DFL_PROMPT_GIT_AT_SIGN="${DFL_PROMPT_IPS_LIST_SPACE:- @ }"
-export DFL_PROMPT_HORIZONTAL_LINE="${DFL_PROMPT_HORIZONTAL_LINE:-}"
-export DFL_PROMPT_TOP_LINE_FIRST_CHAR="${DFL_PROMPT_TOP_LINE_FIRST_CHAR: }"
-export DFL_PROMPT_MID_LINE_FIRST_CHAR="${DFL_PROMPT_MID_LINE_FIRST_CHAR: }"
-export DFL_PROMPT_GIT_LINE_FIRST_CHAR="${DFL_PROMPT_GIT_LINE_FIRST_CHAR: }"
-export DFL_PROMPT_END_LINE_FIRST_CHAR="${DFL_PROMPT_END_LINE_FIRST_CHAR: }"
 
 # shellcheck disable=SC2148
 # -----------------------------------------------------------------------------
 print_horizontal_line(){
     cols=${COLUMNS:-$(tty -s && tput cols)}
-    hline=$(printf "%*s\n" "${cols}" "" | tr " " ${DFL_PROMPT_HORIZONTAL_LINE})
+    hline=$(printf "%*s\n" "${cols}" "" | tr " " ${DFL_PROMPT_HORIZONTAL_LINE:--})
     if [[ $DFL_HORIZONTAL_LINE_PROMPT_COLOR ]]; then
         hline="${DFL_HORIZONTAL_LINE_PROMPT_COLOR}${hline}${COLOR_OFF}"
     fi


### PR DESCRIPTION
Added customisable comma and colon signs especaialy for `${PROMPT_IPS_LIST} `
Now we can change the default look of the `${iface_and_ip}` output 
a customised version can be added to the `my-ps1` file like:

```
export DFL_PROMPT_COMMA="ANYCHARACTER"
export DFL_PROMPT_COLON="ANYCHARACTER"
```
the space between them is added to the default setup in `ps1-setup` file  like:

```
export DFL_PROMPT_COMMA="${DFL_PROMPT_COMMA:-,}"
export DFL_PROMPT_COLON="${DFL_PROMPT_COLON:-: }"
```
this gives the advantage to ingore it with the custom setup
also these could be added for future customised outputs