### PR TITLE
added custom git icons

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,5 +15,5 @@ jobs:
 
       - name: Run shellchecker
         run: |
-          shellcheck ps1/*
+          shellcheck --shell=bash ps1/*
           shellcheck --shell=bash startup-sequence/functions/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## 2021
 
+**May 17, 2021, Corona Days**
+
+Add customization for git PS1 variables;
+
+- `DFL_GIT_SIGN_RIGHT_ARROW`, default: `→`
+- `DFL_GIT_SIGN_LEFT_ARROW`, default: `←`
+- `DFL_GIT_SYMBOL_UNCTRACKED`, default: `□`
+- `DFL_GIT_SYMBOL_ADDED`, default: `■`
+- `DFL_GIT_SYMBOL_MODIFIED`: default: `◆`
+- `DFL_GIT_SYMBOL_RENAMED`: default: `◇`
+- `DFL_GIT_SYMBOL_DELETED`: default: `◌`
+- `DFL_GIT_SYMBOL_TYPECHANGED`: default: `❖`
+
 **May 10 2021, Corona Days**
 
 - Remove `pyenv`, `rbenv`, `pip` autoloader

--- a/README.md
+++ b/README.md
@@ -73,19 +73,24 @@ Try these commands:
 
 ## What’s New ?
 
+**May 17, 2021, Corona Days**
+
+Add customization for git PS1 variables;
+
+- `DFL_GIT_SIGN_RIGHT_ARROW`, default: `→`
+- `DFL_GIT_SIGN_LEFT_ARROW`, default: `←`
+- `DFL_GIT_SYMBOL_UNCTRACKED`, default: `□`
+- `DFL_GIT_SYMBOL_ADDED`, default: `■`
+- `DFL_GIT_SYMBOL_MODIFIED`: default: `◆`
+- `DFL_GIT_SYMBOL_RENAMED`: default: `◇`
+- `DFL_GIT_SYMBOL_DELETED`: default: `◌`
+- `DFL_GIT_SYMBOL_TYPECHANGED`: default: `❖`
+
 **May 10 2021, Corona Days**
 
 - Remove `pyenv`, `rbenv`, `pip` autoloader
 
 You can add required config under `private/` folder for pyenv, rbenv etc.
-
-**May 9, 2021, Corona Days**
-
-- Upgrade bash-completion scripts from https://github.com/mernen/completion-ruby
-- Add github action, shellcheck
-- Add `DFL_PROMPT_IPS_LIST_SEPERATOR` and `DFL_PROMPT_IPS_LIST_COLON` for `PROMPT_IPS_LIST`
-- Add `DFL_PROMPT_HORIZONTAL_LINE` for custom char option for `PROMPT_HORIZONTAL_LINE`
-- Add `DFL_PROMPT_GIT_AT_SIGN` for custom look and feel
 
 Change log is available [here](CHANGELOG.md)
 

--- a/ps1/git
+++ b/ps1/git
@@ -4,15 +4,14 @@
 # feel free to add/change or implement more kool features
 # @vigobronx
 
-sign_right_arrow="\xE2\x86\x92"    # →
-sign_left_arrow="\xE2\x86\x90"     # ←
-symbol_unctracked="\xE2\x96\xA1"   # □ WHITE SQUARE
-symbol_added="\xE2\x96\xA0"        # ■ BLACK SQUARE
-symbol_modified="\xE2\x97\x86"     # ◆ BLACK DIAMOND
-symbol_renamed="\xE2\x97\x87"      # ◇ WHITE DIAMOND
-symbol_deleted="\xE2\x97\x8C"      # ◌ DOTTED CIRCLE
-symbol_typechanged="\xE2\x9A\x91"  # ❖ BLACK DIAMOND MINUS WHITE X
-# symbol_overall="\xE2\x9D\x96"      # ◔ CIRCLE WITH UPPER RIGHT QUADRANT BLACK
+sign_right_arrow="${DFL_GIT_SIGN_RIGHT_ARROW:-\xE2\x86\x92}"      # →
+sign_left_arrow="${DFL_GIT_SIGN_LEFT_ARROW:-\xE2\x86\x90}"        # ←
+symbol_unctracked="${DFL_GIT_SYMBOL_UNCTRACKED:-\xE2\x96\xA1}"    # □ WHITE SQUARE
+symbol_added="${DFL_GIT_SYMBOL_ADDED:-\xE2\x96\xA0}"              # ■ BLACK SQUARE
+symbol_modified="${DFL_GIT_SYMBOL_MODIFIED:-\xE2\x97\x86}"        # ◆ BLACK DIAMOND
+symbol_renamed="${DFL_GIT_SYMBOL_RENAMED:-\xE2\x97\x87}"          # ◇ WHITE DIAMOND
+symbol_deleted="${DFL_GIT_SYMBOL_DELETED:-\xE2\x97\x8C}"          # ◌ DOTTED CIRCLE
+symbol_typechanged="${DFL_GIT_SYMBOL_TYPECHANGED:-\xE2\x9A\x91}"  # ❖ BLACK DIAMOND MINUS WHITE X
 
 git_repo_path=$(git rev-parse --git-dir 2>/dev/null)
 


### PR DESCRIPTION
Changed default git icons to customisable variables.

```DFL_GIT_SIGN_RIGHT_ARROW="${DFL_GIT_SIGN_RIGHT_ARROW:-\xE2\x86\x92}"     # →
DFL_GIT_SIGN_LEFT_ARROW="${DFL_GIT_SIGN_LEFT_ARROW:-\xE2\x86\x90}"       # ←
DFL_GIT_SYMBOL_UNCTRACKED="${DFL_GIT_SYMBOL_UNCTRACKED:-\\xE2\x96\xA1}"  # □ WHITE SQUARE
DFL_GIT_SYMBOL_ADDED="${DFL_GIT_SYMBOL_ADDED:-\xE2\x96\xA0}"             # ■ BLACK SQUARE
DFL_GIT_SYMBOL_MODIFIED="${DFL_GIT_SYMBOL_MODIFIED:-\xE2\x97\x86}"       # ◆ BLACK DIAMOND
DFL_GIT_SYMBOL_RENAMED="${DFL_GIT_SYMBOL_RENAMED:-\xE2\x97\x87}"         # ◇ WHITE DIAMOND
DFL_GIT_SYMBOL_DELETED="${DFL_GIT_SYMBOL_DELETED:-\xE2\x97\x8C}"         # ◌ DOTTED CIRCLE
DFL_GIT_SYMBOL_TYPECHANGED="${DFL_GIT_SYMBOL_TYPECHANGED:-\xE2\x9A\x91}" # ❖ BLACK DIAMOND MINUS WHITE X
```

The default icons are the same as before.  Now you can change them in your `my-ps1`file like:

```
export DFL_GIT_SIGN_RIGHT_ARROW="any character you want"
```